### PR TITLE
Session of 2022-07-29

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,13 @@
 # Notes
 
-## Game rules 
+## Game rules
 
+[x] a game has nine fields in a 3x3 grid
+
+[x] a player can take a field if not already taken
 - a game is over when all fields in a row are taken by a player
+- there are two players in the game (X and O)
 - players take turns taking fields until the game is over
 - a game is over when all fields in a diagonal are taken by a player
 - a game is over when all fields are taken
-- there are two players in the game (X and O)
-- a game has nine fields in a 3x3 grid
 - a game is over when all fields in a column are taken by a player
-- a player can take a field if not already taken

--- a/src/main/java/com/zenika/community/tictactoe/domain/FieldAlreadyTakenException.java
+++ b/src/main/java/com/zenika/community/tictactoe/domain/FieldAlreadyTakenException.java
@@ -1,0 +1,4 @@
+package com.zenika.community.tictactoe.domain;
+
+public class FieldAlreadyTakenException extends Exception {
+}

--- a/src/main/java/com/zenika/community/tictactoe/domain/GameState.java
+++ b/src/main/java/com/zenika/community/tictactoe/domain/GameState.java
@@ -1,0 +1,5 @@
+package com.zenika.community.tictactoe.domain;
+
+public enum GameState {
+    X_WON;
+}

--- a/src/test/java/com/zenika/community/tictactoe/domain/GameTest.java
+++ b/src/test/java/com/zenika/community/tictactoe/domain/GameTest.java
@@ -1,10 +1,14 @@
 package com.zenika.community.tictactoe.domain;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static com.zenika.community.tictactoe.domain.GameState.X_WON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
-public class GameTest {
+class GameTest {
 
     @Test
     void aGameHas9FieldsInA3By3Grid() {
@@ -18,7 +22,7 @@ public class GameTest {
     }
 
     @Test
-    void playersTakeTurnTakingFields() {
+    void playersTakeTurnTakingFields() throws FieldAlreadyTakenException {
         Game game = new Game();
 
         game.takeField(0, 0);
@@ -31,13 +35,30 @@ public class GameTest {
         });
     }
 
-//    @Test
-//    void nextPlayerCannotTakeAFieldAlreadyTaken() {
-//        Game game = new Game();
-//        game.takeField(0, 0);
-//
-//        game.takeField(0, 0);
-//
-//        assertThatThrownBy()
-//    }
+    @Test
+    void aPlayerCannotTakeAFieldAlreadyTaken() throws FieldAlreadyTakenException {
+        Game game = new Game();
+        game.takeField(0, 0);
+
+        var thrown = catchThrowable(() -> {
+            game.takeField(0, 0);
+        });
+
+        assertThat(thrown).isInstanceOf(FieldAlreadyTakenException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void aGameIsOverWhenAllFieldsInARowAreTakenByAPlayer(final int takenRow) throws FieldAlreadyTakenException {
+        final var game = new Game();
+        final var anotherRow = (takenRow + 1) % 3;
+        game.takeField(0, takenRow);
+        game.takeField(0, anotherRow);
+        game.takeField(1, takenRow);
+        game.takeField(1, anotherRow);
+
+        game.takeField(2, takenRow);
+
+        assertThat(game.state()).isEqualTo(X_WON);
+    }
 }


### PR DESCRIPTION
Throughout this session:
- we finished the unit test `aPlayerCannotTakeAFieldAlreadyTaken` while debating about the best approach to assert exceptions
- we started implementing the actual solution for the case of rows (c.f. `aGameIsOverWhenAllFieldsInARowAreTakenByAPlayer`)

Next steps:
- implement column and transversal-winning scenarios